### PR TITLE
Weaker checks for file permissions

### DIFF
--- a/src/Modules/Health_Checks/Security/Bm_Config_Check.php
+++ b/src/Modules/Health_Checks/Security/Bm_Config_Check.php
@@ -33,7 +33,7 @@ class Bm_Config_Check extends Security_Check {
         $files = glob( ABSPATH . 'config{,*/,*/*/,*/*/*/}*.php', GLOB_BRACE );
 
         foreach ( $files as $file ) {
-            if ( Helpers::get_file_permissions( $file ) >= 440 ) {
+            if ( Helpers::get_file_permissions( $file ) >= 640 ) {
                 return false;
             }
         }

--- a/src/Modules/Health_Checks/Security/Wp_Config_Permissions_Check.php
+++ b/src/Modules/Health_Checks/Security/Wp_Config_Permissions_Check.php
@@ -5,34 +5,29 @@ namespace BernskioldMedia\WP\Experience\Modules\Health_Checks\Security;
 use BernskioldMedia\WP\Experience\Helpers;
 
 class Wp_Config_Permissions_Check extends Security_Check {
-    public static string $key = 'bm_wp_config_permissions';
 
-    protected static function test(): array {
-        $result = [
-            'label'       => __( 'The wp-config.php file is not readable.', 'bm-wp-experience' ),
-            'status'      => 'good',
-            'description' => sprintf(
-                '<p>%s</p>',
-                __( 'When the wp-config.php file is protected there is less risk of important configuration secrets becoming exposed.', 'bm-wp-experience' )
-            ),
-        ];
+	public static string $key = 'bm_wp_config_permissions';
 
-        if ( 440 < Helpers::get_file_permissions( ABSPATH . 'wp-config.php' ) ) {
-            $result['status']      = 'critical';
-            $result['label']       = __( 'The wp-config.php file is publicly readable.', 'bm-wp-experience' );
-            $result['description'] = sprintf(
-                '<p>%s</p>',
-                __(
-                    'It could be possible to access the wp-config.php file publicly. To fix, please CHMOD the file to a permission set less than, or equal to 440.',
-                    'bm-wp-experience'
-                )
-            );
-        }
+	protected static function test(): array {
+		$result = [
+			'label'       => __( 'The wp-config.php file is not readable.', 'bm-wp-experience' ),
+			'status'      => 'good',
+			'description' => sprintf( '<p>%s</p>',
+				__( 'When the wp-config.php file is protected there is less risk of important configuration secrets becoming exposed.', 'bm-wp-experience' ) ),
+		];
 
-        return $result;
-    }
+		if ( 640 <= Helpers::get_file_permissions( ABSPATH . 'wp-config.php' ) ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'The wp-config.php file is publicly readable.', 'bm-wp-experience' );
+			$result['description'] = sprintf( '<p>%s</p>',
+				__( 'It could be possible to access the wp-config.php file publicly. To fix, please CHMOD the file to a permission set less than, or equal to 440.',
+					'bm-wp-experience' ) );
+		}
 
-    public static function get_label(): string {
-        return __( 'WP-Config File Permissions', 'bm-wp-experience' );
-    }
+		return $result;
+	}
+
+	public static function get_label(): string {
+		return __( 'WP-Config File Permissions', 'bm-wp-experience' );
+	}
 }


### PR DESCRIPTION
This PR weakens the site check for file permissions to 640 instead of 440 for config files except .env.