### PR TITLE
File would be loaded twice causing error

### DIFF
--- a/src/Modules/Health_Checks/Security/Bm_Config_Check.php
+++ b/src/Modules/Health_Checks/Security/Bm_Config_Check.php
@@ -5,43 +5,40 @@ namespace BernskioldMedia\WP\Experience\Modules\Health_Checks\Security;
 use BernskioldMedia\WP\Experience\Helpers;
 
 class Bm_Config_Check extends Security_Check {
-    public static string $key = 'bm_config_permissions';
 
-    protected static function test(): array {
-        $result = [
-            'label'       => __( 'Configuration files properly secured.', 'bm-wp-experience' ),
-            'status'      => 'good',
-            'description' => sprintf( '<p>%s</p>', __( 'The application and environment configuration files are properly secured.', 'bm-wp-experience' ) ),
-        ];
+	public static string $key = 'bm_config_permissions';
 
-        if ( ! self::all_files_pass() ) {
-            $result['status']      = 'critical';
-            $result['label']       = __( 'Configuration files needs securing.', 'bm-wp-experience' );
-            $result['description'] = sprintf(
-                '<p>%s</p>',
-                __(
-                    'It could be possible to access the files in the config directory. To fix, please CHMOD the file to a permission set less than, or equal to 440.',
-                    'bm-wp-experience'
-                )
-            );
-        }
+	protected static function test(): array {
+		$result = [
+			'label'       => __( 'Configuration files properly secured.', 'bm-wp-experience' ),
+			'status'      => 'good',
+			'description' => sprintf( '<p>%s</p>', __( 'The application and environment configuration files are properly secured.', 'bm-wp-experience' ) ),
+		];
 
-        return $result;
-    }
+		if ( ! self::all_files_pass() ) {
+			$result['status']      = 'critical';
+			$result['label']       = __( 'Configuration files needs securing.', 'bm-wp-experience' );
+			$result['description'] = sprintf( '<p>%s</p>',
+				__( 'It could be possible to access the files in the config directory. To fix, please CHMOD the file to a permission set less than, or equal to 440.',
+					'bm-wp-experience' ) );
+		}
 
-    protected static function all_files_pass(): bool {
-        $files = glob( ABSPATH . 'config{,*/,*/*/,*/*/*/}*.php', GLOB_BRACE );
+		return $result;
+	}
 
-        foreach ( $files as $file ) {
-            if ( Helpers::get_file_permissions( $file ) >= 640 ) {
-                return false;
-            }
-        }
+	protected static function all_files_pass(): bool {
+		$files = glob( ABSPATH . 'config{,*/,*/*/,*/*/*/}*.php', GLOB_BRACE );
 
-        return true;
-    }
+		foreach ( $files as $file ) {
+			if ( Helpers::get_file_permissions( $file ) > 640 ) {
+				return false;
+			}
+		}
 
-    public static function get_label(): string {
-        return __( 'Configuration File Permissions', 'bm-wp-experience' );
-    }
+		return true;
+	}
+
+	public static function get_label(): string {
+		return __( 'Configuration File Permissions', 'bm-wp-experience' );
+	}
 }

--- a/src/Modules/Health_Checks/Security/Wp_Config_Permissions_Check.php
+++ b/src/Modules/Health_Checks/Security/Wp_Config_Permissions_Check.php
@@ -16,7 +16,7 @@ class Wp_Config_Permissions_Check extends Security_Check {
 				__( 'When the wp-config.php file is protected there is less risk of important configuration secrets becoming exposed.', 'bm-wp-experience' ) ),
 		];
 
-		if ( 640 <= Helpers::get_file_permissions( ABSPATH . 'wp-config.php' ) ) {
+		if ( Helpers::get_file_permissions( ABSPATH . 'wp-config.php' ) > 644 ) {
 			$result['status']      = 'critical';
 			$result['label']       = __( 'The wp-config.php file is publicly readable.', 'bm-wp-experience' );
 			$result['description'] = sprintf( '<p>%s</p>',

--- a/src/Rest/OhDear_Application_Health.php
+++ b/src/Rest/OhDear_Application_Health.php
@@ -34,9 +34,9 @@ class OhDear_Application_Health implements Hookable {
 			], 403 );
 		}
 
-		include ABSPATH . 'wp-admin/includes/update.php';
-		include ABSPATH . 'wp-admin/includes/plugin.php';
-		include ABSPATH . 'wp-admin/includes/misc.php';
+		require_once ABSPATH . 'wp-admin/includes/update.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
 
 		$check_results = new CheckResults( new DateTime() );
 		$site_health   = WP_Site_Health::get_instance();


### PR DESCRIPTION
This PR fixes an issue where an include file could be loaded twice and throw a fatal error.