### PR TITLE
Add support for SMTP e-mail sending

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ For almost every feature there is a filter, constant or action allowing you to c
 - Show staging environment notice publically for administrators.
 - Disable indexing for non-production environments.
 
+### Mail
+
+- Allows easy configuration of sending via SMTP instead of PHP Sendmail.
+
 ### Media
 
 - Sanitize uploaded file names from non-ASCII characters.
@@ -159,6 +163,16 @@ configuration.
 `bm_wpexp_environment_disable_indexing_for_non_production` - Return `false` to enable indexing for non-production environments.
 `bm_wpexp_environment_staging_public_label` - Customize the label shown on the public staging environment banner.
 
+### Mail
+
+`BM_WP_SMTP_ENABLED` - Set to `true` to send e-mail via SMTP. By default this will only apply to production environments.
+`BM_WP_SMTP_OUTSIDE_PRODUCTION` - Set to `true` to send e-mail via SMTP even if the environment is not set as production.
+`BM_WP_SMTP_HOST` - Define the SMTP host to send through.
+`BM_WP_SMTP_USERNAME` - Define the SMTP e-mail account username to send through.
+`BM_WP_SMTP_PASSWORD` - Define the SMTP e-mail account password to send through.
+`BM_WP_SMTP_PORT` - Set which port the connection should be made through. Should be set as an integer. Defaults to `587`.
+`BM_WP_SMTP_SECURITY` - Set the sending security for the SMTP server. Defaults to `tls`.
+
 ### REST API
 
 **Choose API restriction level:** By default, the REST API requires authentication for all endpoints. By setting the `BM_WP_RESTRICT_REST_API` constant you may change this. `all` (
@@ -204,4 +218,5 @@ To run this endpoint, a secret must be configured and defined in your config:
 define( 'BM_WP_OH_DEAR_SECRET', 'my-secret-here' );
 ```
 
-The same secret needs to be defined in OhDear's settings. It will then be sent via all requests to the API. The secrets in OhDear and the application must match for proper authentication.
+The same secret needs to be defined in OhDear's settings. It will then be sent via all requests to the API. The secrets in OhDear and the application must match for proper
+authentication.

--- a/src/Modules/Mail.php
+++ b/src/Modules/Mail.php
@@ -9,11 +9,37 @@ class Mail implements Hookable {
 
 	public static function hooks(): void {
 		add_action( 'phpmailer_init', [ self::class, 'send_mail_via_smtp' ] );
+		add_action( 'admin_notices', [ self::class, 'warn_improper_smtp_configuration' ] );
+	}
+
+	public static function warn_improper_smtp_configuration(): void {
+
+		if ( ! self::should_send_via_smtp() ) {
+			return;
+		}
+
+		if ( self::are_all_configs_set() ) {
+			return;
+		}
+
+		?>
+		<div class="notice notice-error">
+			<p>
+				<strong><?php esc_html_e( 'E-Mails Not Sending:' ); ?></strong>
+			</p>
+			<p><?php esc_html_e( 'Sending via SMTP is currently enabled but the configuration has not been properly set in the configuration files. Sending via SMTP is therefore disabled and e-mail will be send via the default PHP sendmail functions.', 'bm-wp-experience' ); ?></p>
+			<p><?php esc_html_e( 'You can fix this error by either disabling SMTP in the configuration, or providing proper configuration values.', 'bm-wp-experience' ); ?></p>
+		</div>
+		<?php
 	}
 
 	public static function send_mail_via_smtp( PHPMailer $mailer ): void {
 
 		if ( ! self::should_send_via_smtp() ) {
+			return;
+		}
+
+		if ( ! self::are_all_configs_set() ) {
 			return;
 		}
 
@@ -55,11 +81,15 @@ class Mail implements Hookable {
 	}
 
 	protected static function get_smtp_port(): int {
-		return defined( 'BM_WP_SMTP_PORT' ) ? BM_WP_SMTP_PORT : 587;
+		return defined( 'BM_WP_SMTP_PORT' ) ? (int) BM_WP_SMTP_PORT : 587;
 	}
 
-	protected static function get_smtp_secure_type(): string {
+	protected static function get_smtp_secure_type(): ?string {
 		return defined( 'BM_WP_SMTP_SECURITY' ) ? BM_WP_SMTP_SECURITY : 'tls';
+	}
+
+	protected static function are_all_configs_set(): bool {
+		return ! empty( self::get_smtp_host() ) && ! empty( self::get_smtp_username() ) && ! empty( self::get_smtp_password() ) && is_int( self::get_smtp_port() );
 	}
 
 }

--- a/src/Modules/Mail.php
+++ b/src/Modules/Mail.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace BernskioldMedia\WP\Experience\Modules;
+
+use BernskioldMedia\WP\PluginBase\Interfaces\Hookable;
+use PHPMailer\PHPMailer\PHPMailer;
+
+class Mail implements Hookable {
+
+	public static function hooks(): void {
+		add_action( 'phpmailer_init', [ self::class, 'send_mail_via_smtp' ] );
+	}
+
+	public static function send_mail_via_smtp( PHPMailer $mailer ): void {
+
+		if ( ! self::should_send_via_smtp() ) {
+			return;
+		}
+
+		$mailer->set( 'Host', self::get_smtp_host() );
+		$mailer->set( 'Port', self::get_smtp_port() );
+		$mailer->set( 'Username', self::get_smtp_username() );
+		$mailer->set( 'Password', self::get_smtp_password() );
+		$mailer->set( 'SMTPAuth', true );
+		$mailer->set( 'SMTPSecure', self::get_smtp_secure_type() );
+		$mailer->isSMTP();
+	}
+
+	protected static function should_send_via_smtp(): bool {
+		if ( 'production' !== wp_get_environment_type() ) {
+			return self::should_send_smtp_outside_production();
+		}
+
+		return self::should_send_smtp_in_production();
+	}
+
+	protected static function should_send_smtp_outside_production(): bool {
+		return defined( 'BM_WP_SMTP_OUTSIDE_PRODUCTION' ) && true === BM_WP_SMTP_OUTSIDE_PRODUCTION;
+	}
+
+	protected static function should_send_smtp_in_production(): bool {
+		return defined( 'BM_WP_SMTP_ENABLED' ) && true === BM_WP_SMTP_ENABLED;
+	}
+
+	protected static function get_smtp_host(): ?string {
+		return defined( 'BM_WP_SMTP_HOST' ) ? BM_WP_SMTP_HOST : null;
+	}
+
+	protected static function get_smtp_username(): ?string {
+		return defined( 'BM_WP_SMTP_USERNAME' ) ? BM_WP_SMTP_USERNAME : null;
+	}
+
+	protected static function get_smtp_password(): ?string {
+		return defined( 'BM_WP_SMTP_PASSWORD' ) ? BM_WP_SMTP_PASSWORD : null;
+	}
+
+	protected static function get_smtp_port(): int {
+		return defined( 'BM_WP_SMTP_PORT' ) ? BM_WP_SMTP_PORT : 587;
+	}
+
+	protected static function get_smtp_secure_type(): string {
+		return defined( 'BM_WP_SMTP_SECURITY' ) ? BM_WP_SMTP_SECURITY : 'tls';
+	}
+
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -8,9 +8,9 @@ use BMWPEXP_Vendor\BernskioldMedia\WP\PluginBase\BasePlugin;
 
 class Plugin extends BasePlugin {
 
-	protected static string $slug             = 'bm-wp-experience';
-	protected static string $version          = '3.2.1';
-	protected static string $textdomain       = 'bm-wp-experience';
+	protected static string $slug = 'bm-wp-experience';
+	protected static string $version = '3.2.1';
+	protected static string $textdomain = 'bm-wp-experience';
 	protected static string $plugin_file_path = BM_WP_EXPERIENCE_FILE_PATH;
 
 	protected static array $boot = [
@@ -33,6 +33,7 @@ class Plugin extends BasePlugin {
 		Modules\Customizer::class,
 		Modules\Dashboard::class,
 		Modules\Environments::class,
+		Modules\Mail::class,
 		Modules\Media::class,
 		Modules\Multisite::class,
 		Modules\Plugins::class,


### PR DESCRIPTION
This PR adds support for sending e-mail via SMTP. It applies globally.

Adding this means hooking into the PHP Mailer configuration and updating it. While this is easily done, it's unnecessary for every site. Therefore we make this into a set of defines that can be placed in the environment config instead:

```php

define( 'BM_WP_SMTP_ENABLED', true );
define( 'BM_WP_SMTP_OUTSIDE_PRODUCTION', true );
define( 'BM_WP_SMTP_USERNAME', '' );
define( 'BM_WP_SMTP_PASSWORD', '' );
define( 'BM_WP_SMTP_HOST', '' );
```

By default, if enabled, we only send via SMTP if `wp_get_environment_type()` returns production. This is to prevent sending e-mail accidentally in local if you expect a local mail catcher to catch the e-mail. A failsafe so to speak. A second define lets you process on SMTP outside of production too.