### PR TITLE
Seriously Simple Podcasting Integration: Show all episodes in feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ The SearchWP integration automatically runs if SearchWP is active.
 - Adds common-sense default HTTP headers to .htaccess on install.
 - Adds rule to .htaccess to disable XMLRPC.
 
+### Seriously Simple Podcasting
+
+- Always show all (100 000) episodes of a podcast in the podcast feed that goes out to platforms.
+
 ### Site Health
 
 - Check that `wp-config.php` is secured properly.
@@ -186,6 +190,10 @@ config. By default all core roles with admin access are required to opt in.
 `bm_wpexp_weak_passwords` - Customize the array of passwords that are always considered weak.
 `bm_wpexp_roles_requiring_two_factor` - Customize the array of roles which are required to have two-factor authentication enabled.
 `bm_wpexp_modify_htaccess_on_install` - Return false to stop the .htaccess file from being modified on install.
+
+### Seriously Simple Podcasting
+
+`bm_wpexp_sspodcast_posts_in_feed` - Customize how many posts should show up in the podcasting feeds. Defaults to 100 000.
 
 ### Updates
 

--- a/src/Integrations/SSPodcast.php
+++ b/src/Integrations/SSPodcast.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BernskioldMedia\WP\Experience\Integrations;
+
+class SSPodcast extends Integration {
+
+	public static string $plugin_file = 'seriously-simple-podcasting/seriously-simple-podcasting.php';
+
+	public static function hooks(): void {
+		add_filter( 'ssp_feed_number_of_posts', [ self::class, 'modify_number_of_posts_in_feed' ], 100 );
+	}
+
+	public static function modify_number_of_posts_in_feed() {
+		return apply_filters( 'bm_wpexp_sspodcast_posts_in_feed', 100000 );
+	}
+
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -47,6 +47,7 @@ class Plugin extends BasePlugin {
 	protected static array $integrations = [
 		Integrations\SearchWp::class,
 		Integrations\WooCommerce::class,
+		Integrations\SSPodcast::class,
 	];
 
 	public function __construct() {


### PR DESCRIPTION
If the site uses Seriously Simple Podcasting we integrate with it to customize the experience with more sensible defaults.

This PR adds a filter (`bm_wpexp_sspodcast_posts_in_feed`) that lets you customize the number of episodes in the feeds. By default this is increased to 100 000 instead of the website defaults. It is likely that you want all episodes showing in podcast feeds and not just the latest.