### PR TITLE
Add custom block editor styling for better experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For almost every feature there is a filter, constant or action allowing you to c
 
 - Disable the block directory.
 - Remove Yoast SEO metabox in the block editor.
+- Styles the post editor and title to be less part of the page and more title to better go with the template.
 
 ### Cleanup
 
@@ -141,6 +142,8 @@ The WooCommerce integration automatically runs if WooCommerce is active.
 ### Block Editor
 
 **Enable Block Directory:** By default the block directory is disabled. Define and set `BM_WP_ENABLE_BLOCK_DIRECTORY` to `false` to allow it.
+
+**Disable Block Editor Styling** By default we ship a block editor styling. By returning the `bm_wpexp_enable_block_editor_styling` as false you can disable this, for example via an mu-plugin. `apply_filters( 'bm_wpexp_enable_block_editor_styling', '__return_false' )`.
 
 ### Cleanup
 

--- a/assets/styles/src/block-editor.scss
+++ b/assets/styles/src/block-editor.scss
@@ -1,0 +1,33 @@
+.editor-styles-wrapper {
+	padding-top: 0;
+
+	> .is-root-container.block-editor-block-list__layout {
+		> .wp-block:first-child:not([data-align="full"]) {
+			margin-top: 2rem;
+		}
+	}
+}
+
+.edit-post-visual-editor__post-title-wrapper {
+	border-bottom: 1px solid #cccccc;
+	margin: 0 -8px 0;
+}
+
+.editor-styles-wrapper .edit-post-visual-editor__post-title-wrapper .editor-post-title__input {
+	max-width: none;
+	margin: 0;
+	font-size: 1.25rem;
+	font-weight: bold;
+	font-family: apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	padding: 1rem 2rem;
+	text-align: center;
+}
+
+.components-popover.block-editor-block-list__block-popover {
+	z-index: 9999; // Ensure toolbar appears much higher up in the DOM.
+}
+
+html :where(.wp-block) {
+	margin-top: 0;
+	margin-bottom: 0;
+}

--- a/src/Modules/Block_Editor.php
+++ b/src/Modules/Block_Editor.php
@@ -61,6 +61,10 @@ class Block_Editor extends Module {
 			return;
 		}
 
+		if ( true !== apply_filters( 'bm_wpexp_enable_block_editor_styling', true ) ) {
+			return;
+		}
+
 		wp_enqueue_style( 'bm-block-editor', Plugin::get_assets_url( 'styles/dist/block-editor.css' ), [], Plugin::get_version() );
 	}
 

--- a/src/Modules/Block_Editor.php
+++ b/src/Modules/Block_Editor.php
@@ -9,6 +9,8 @@
 
 namespace BernskioldMedia\WP\Experience\Modules;
 
+use BernskioldMedia\WP\Experience\Plugin;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -18,6 +20,7 @@ class Block_Editor extends Module {
 	public static function hooks(): void {
 		// Disable the block directory in the editor.
 		add_action( 'plugins_loaded', [ self::class, 'disable_block_directory' ] );
+		add_action( 'admin_enqueue_scripts', [ self::class, 'block_editor_styles' ] );
 	}
 
 	/**
@@ -51,6 +54,14 @@ class Block_Editor extends Module {
 				remove_meta_box( 'wpseo_meta', $post_type, 'normal' );
 			}
 		}
+	}
+
+	public static function block_editor_styles(): void {
+		if ( ! self::is_block_editor() ) {
+			return;
+		}
+
+		wp_enqueue_style( 'bm-block-editor', Plugin::get_assets_url( 'styles/dist/block-editor.css' ), [], Plugin::get_version() );
 	}
 
 	/**

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -67,4 +67,5 @@ const sassConfig = {
 // Process the scss files.
 mix.sass( `${ assetPaths.styles }/src/admin-bar.scss`, `${ assetPaths.styles }/dist`, sassConfig )
    .sass( `${ assetPaths.styles }/src/admin.scss`, `${ assetPaths.styles }/dist`, sassConfig )
-   .sass( `${ assetPaths.styles }/src/admin-theme.scss`, `${ assetPaths.styles }/dist`, sassConfig );
+   .sass( `${ assetPaths.styles }/src/admin-theme.scss`, `${ assetPaths.styles }/dist`, sassConfig )
+	.sass( `${assetPaths.styles}/src/block-editor.scss`, `${assetPaths.styles}/dist`, sassConfig );


### PR DESCRIPTION
With the backend quickly starting to mimick the frontend, the editor title is off for almost everything. It just doesn't display the way it does in the editor.

This PR adds styling to make the post title more part of the editor interface and less part of the page and post itself. It also adds some styling to better make the editor experience feel like a fullscreen experience by removing some odd margins.