### PR TITLE
Hide plugin ads in the admin panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For almost every feature there is a filter, constant or action allowing you to c
 - Custom branded admin theme in our colors.
 - Removes ACF settings if on production environment.
 - Remove "Howdy" from the admin bar.
+- Removes ads from a series of plugins
 
 ### Block Editor
 
@@ -135,6 +136,8 @@ The WooCommerce integration automatically runs if WooCommerce is active.
 
 **Enable Import/Export Screens:** By default we hide the import/export pages. If you need these in the menu, set `BM_WP_ENABLE_IMPORT_EXPORT` to `true`.
 
+**Show ads from plugins:** If you for some reason would like to show ads from plugins in the admin, you can set the `bm_wpexp_enable_admin_ad_blocker` filter to false: `add_filter( 'bm_wpexp_enable_admin_ad_blocker', '__return_false' )`.
+
 `bm_wpexp_custom_admin_theme` - Return false to disable our custom branding.
 `bm_wpexp_show_help_widget` - Return false to hide the BM help widget.
 `bm_wpexp_show_admin_page_support` - Return false to hide the support admin page.
@@ -143,7 +146,9 @@ The WooCommerce integration automatically runs if WooCommerce is active.
 
 **Enable Block Directory:** By default the block directory is disabled. Define and set `BM_WP_ENABLE_BLOCK_DIRECTORY` to `false` to allow it.
 
-**Disable Block Editor Styling** By default we ship a block editor styling. By returning the `bm_wpexp_enable_block_editor_styling` as false you can disable this, for example via an mu-plugin. `apply_filters( 'bm_wpexp_enable_block_editor_styling', '__return_false' )`.
+**Disable Block Editor Styling** By default we ship a block editor styling. By returning the `bm_wpexp_enable_block_editor_styling` as false you can disable this, for example via a mu-plugin. `add_filter( 'bm_wpexp_enable_block_editor_styling', '__return_false' )`.
+
+**Hides Yoast Metabox** Yoast SEO has a lovely block editor plugin which works great. So we prefer to get rid of the metabox. We hide it with plain CSS.
 
 ### Cleanup
 

--- a/assets/styles/src/block-editor.scss
+++ b/assets/styles/src/block-editor.scss
@@ -31,3 +31,10 @@ html :where(.wp-block) {
 	margin-top: 0;
 	margin-bottom: 0;
 }
+
+/**
+ * Hide Yoast Metabox
+ */
+#wpseo_meta {
+	display: none;
+}

--- a/src/Modules/Admin_Ad_Blocker.php
+++ b/src/Modules/Admin_Ad_Blocker.php
@@ -38,8 +38,12 @@ class Admin_Ad_Blocker extends Module {
 	}
 
 	public static function hide_ad_pages(): void {
-		remove_submenu_page( 'wpseo_dashboard', 'wpseo_licenses' );
-		remove_submenu_page( 'wpseo_dashboard', 'wpseo_workouts' );
+
+		// Remove premium only pages from Yoast unless we are running premium.
+		if ( ! YoastSEO()->helpers->product->is_premium() ) {
+			remove_submenu_page( 'wpseo_dashboard', 'wpseo_licenses' );
+			remove_submenu_page( 'wpseo_dashboard', 'wpseo_workouts' );
+		}
 	}
 
 	protected static function get_ad_selectors(): string {

--- a/src/Modules/Admin_Ad_Blocker.php
+++ b/src/Modules/Admin_Ad_Blocker.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace BernskioldMedia\WP\Experience\Modules;
+
+class Admin_Ad_Blocker extends Module {
+
+	public static function hooks(): void {
+
+		// This module only runs in admin.
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		// Allow disabling of module.
+		if ( true !== apply_filters( 'bm_wpexp_enable_admin_ad_blocker', true ) ) {
+			return;
+		}
+
+		add_action( 'admin_head', [ self::class, 'styles' ] );
+
+	}
+
+	public static function styles(): void {
+		$selectors = self::get_ad_selectors();
+
+		if ( empty( $selectors ) ) {
+			return;
+		}
+
+		?>
+		<style>
+			<?php echo $selectors; ?>
+			{
+				display: none !important
+			;
+			}
+		</style>
+		<?php
+	}
+
+	protected static function get_ad_selectors(): string {
+		$selectors = apply_filters( 'bm_wpexp_admin_ads_selectors', [
+			'.wpseo_content_wrapper #sidebar-container',
+			'.yoast_premium_upsell',
+			'#wpseo-local-seo-upsell',
+			'.yoast-settings-section-upsell',
+			'#bwp-get-social',
+			'.bwp-button-paypal',
+			'#bwp-sidebar-right',
+			'.tjcc-custom-css #postbox-container-1',
+			'.settings_page_wpcustomtaxfilterinadmin #postbox-container-1',
+			'#duplicate-post-notice #newsletter-subscribe-form',
+			'div[id^="dnh-wrm"]',
+			'.notice-info.dst-notice',
+			'#googleanalytics_terms_notice',
+			'.fw-brz-dismiss',
+			'div.elementor-message[data-notice_id="elementor_dev_promote"]',
+			'.notice-success.wpcf7r-notice',
+			'.dc-text__block.disable__comment__alert',
+			'#ws_sidebar_pro_ad',
+			'.pa-new-feature-notice',
+			'#redux-connect-message',
+			'.frash-notice-email',
+			'.frash-notice-rate',
+			'#smush-box-pro-features',
+			'#wp-smush-bulk-smush-upsell-row',
+			'#easy-updates-manager-dashnotice',
+			'#metaslider-optin-notice',
+			'#extendifysdk_announcement',
+			'.updraft-ad-container',
+			'.mo-admin-notice',
+			'.post-smtp-donation',
+			'div[data-dismissible="notice-owa-sale-forever"]',
+			'.neve-notice-upsell',
+			'#pagelayer_promo',
+			'#simple-custom-post-order-epsilon-review-notice',
+			'.sfsi_new_prmium_follw',
+			'div.fs-slug-the-events-calendar[data-id="connect_account"]',
+			'div.notice[data-notice="webp-converter-for-media"]',
+			'.webpLoader__popup.webpPopup',
+			'.put-dismiss-notice',
+			'.wp-mail-smtp-review-notice',
+			'#wp-mail-smtp-pro-banner',
+			'body div.promotion.fs-notice',
+			'.analytify-review-thumbnail',
+			'.jitm-banner.is-upgrade-premium',
+			'div[data-name*="wbcr_factory_notice_adverts"]',
+			'.sui-subscription-notice',
+			'#sui-cross-sell-footer',
+			'.sui-cross-sell-modules',
+			'.forminator-rating-notice',
+			'.sui-dashboard-upsell-upsell',
+			'.anwp-post-grid__rate',
+			'.cff-settings-cta',
+		] );
+
+		return implode( ', ', $selectors );
+	}
+
+}

--- a/src/Modules/Admin_Ad_Blocker.php
+++ b/src/Modules/Admin_Ad_Blocker.php
@@ -17,6 +17,7 @@ class Admin_Ad_Blocker extends Module {
 		}
 
 		add_action( 'admin_head', [ self::class, 'styles' ] );
+		add_action( 'admin_init', [ self::class, 'hide_ad_pages' ], 9999 );
 
 	}
 
@@ -27,19 +28,24 @@ class Admin_Ad_Blocker extends Module {
 			return;
 		}
 
+		// @formatter:off
 		?>
 		<style>
-			<?php echo $selectors; ?>
-			{
-				display: none !important
-			;
-			}
+<?php echo $selectors; ?> { display: none !important; }
 		</style>
 		<?php
+		// @formatter:on
+	}
+
+	public static function hide_ad_pages(): void {
+		remove_submenu_page( 'wpseo_dashboard', 'wpseo_licenses' );
+		remove_submenu_page( 'wpseo_dashboard', 'wpseo_workouts' );
 	}
 
 	protected static function get_ad_selectors(): string {
 		$selectors = apply_filters( 'bm_wpexp_admin_ads_selectors', [
+			'#yoast-helpscout-beacon',
+			'.yoast-container__configuration-wizard',
 			'.wpseo_content_wrapper #sidebar-container',
 			'.yoast_premium_upsell',
 			'#wpseo-local-seo-upsell',

--- a/src/Modules/Dashboard.php
+++ b/src/Modules/Dashboard.php
@@ -10,53 +10,55 @@ namespace BernskioldMedia\WP\Experience\Modules;
 
 use BernskioldMedia\WP\Experience\Plugin;
 
-if (!defined('ABSPATH')) {
-    exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
 class Dashboard extends Module {
-    public static function hooks(): void {
-        add_action('wp_dashboard_setup', [self::class, 'remove_dashboard_widgets']);
-        add_action('wp_network_dashboard_setup', [self::class, 'remove_dashboard_widgets']);
-        add_action('wp_user_dashboard_setup', [self::class, 'remove_dashboard_widgets']);
 
-        add_action('wp_dashboard_setup', [self::class, 'add_bm_academy_dashboard_widget']);
-    }
+	public static function hooks(): void {
+		add_action( 'wp_dashboard_setup', [ self::class, 'remove_dashboard_widgets' ] );
+		add_action( 'wp_network_dashboard_setup', [ self::class, 'remove_dashboard_widgets' ] );
+		add_action( 'wp_user_dashboard_setup', [ self::class, 'remove_dashboard_widgets' ] );
 
-    /**
-     * Remove Dashboard Widgets
-     */
-    public static function remove_dashboard_widgets(): void {
-        remove_meta_box('dashboard_primary', get_current_screen(), 'side');
-        remove_meta_box('dashboard_secondary', get_current_screen(), 'side');
-        remove_meta_box('dashboard_plugins', get_current_screen(), 'normal');
-        remove_meta_box('dashboard_incoming_links', get_current_screen(), 'normal');
-        remove_meta_box('dashboard_quick_press', get_current_screen(), 'side');
-        remove_meta_box('dashboard_recent_drafts', get_current_screen(), 'side');
+		add_action( 'wp_dashboard_setup', [ self::class, 'add_bm_academy_dashboard_widget' ] );
+	}
 
-        remove_meta_box('wpseo-dashboard-overview', get_current_screen(), 'side');
+	/**
+	 * Remove Dashboard Widgets
+	 */
+	public static function remove_dashboard_widgets(): void {
+		remove_meta_box( 'dashboard_primary', get_current_screen(), 'side' );
+		remove_meta_box( 'dashboard_secondary', get_current_screen(), 'side' );
+		remove_meta_box( 'dashboard_plugins', get_current_screen(), 'normal' );
+		remove_meta_box( 'dashboard_incoming_links', get_current_screen(), 'normal' );
+		remove_meta_box( 'dashboard_quick_press', get_current_screen(), 'side' );
+		remove_meta_box( 'dashboard_recent_drafts', get_current_screen(), 'side' );
 
-        if (Updates::is_on_maintenance_plan()) {
-            remove_meta_box('dashboard_site_health', 'dashboard', 'normal');
-        }
-    }
+		remove_meta_box( 'wpseo-dashboard-overview', get_current_screen(), 'side' );
+		remove_meta_box( 'tribe_dashboard_widget', get_current_screen(), 'side' );
 
-    public static function add_bm_academy_dashboard_widget(): void {
-        wp_add_dashboard_widget('bm_academy', __('Bernskiold Media Academy', 'bm-wp-experience'), static function () {
-            $feed = fetch_feed(_x('https://bernskioldmedia.com/en/feed/', 'academy feed', 'bm-wp-experience'));
+		if ( Updates::is_on_maintenance_plan() ) {
+			remove_meta_box( 'dashboard_site_health', 'dashboard', 'normal' );
+		}
+	}
 
-            if (is_wp_error($feed)) {
-                echo __('Unfortunately the academy content is not currently available.', 'bm-wp-experience');
-            } else {
-                $feed->init();
-                $feed->set_output_encoding('UTF-8');
-                $feed->handle_content_type();
-                $feed->set_cache_duration(21600);
-                $limit = $feed->get_item_quantity(5);
-                $items = $feed->get_items(0, $limit);
+	public static function add_bm_academy_dashboard_widget(): void {
+		wp_add_dashboard_widget( 'bm_academy', __( 'Bernskiold Media Academy', 'bm-wp-experience' ), static function () {
+			$feed = fetch_feed( _x( 'https://bernskioldmedia.com/en/feed/', 'academy feed', 'bm-wp-experience' ) );
 
-                include Plugin::get_view_path('dashboard-widgets/academy-feed');
-            }
-        }, null, null, 'side');
-    }
+			if ( is_wp_error( $feed ) ) {
+				echo __( 'Unfortunately the academy content is not currently available.', 'bm-wp-experience' );
+			} else {
+				$feed->init();
+				$feed->set_output_encoding( 'UTF-8' );
+				$feed->handle_content_type();
+				$feed->set_cache_duration( 21600 );
+				$limit = $feed->get_item_quantity( 5 );
+				$items = $feed->get_items( 0, $limit );
+
+				include Plugin::get_view_path( 'dashboard-widgets/academy-feed' );
+			}
+		}, null, null, 'side' );
+	}
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -27,6 +27,7 @@ class Plugin extends BasePlugin {
 	];
 
 	protected static array $modules = [
+		Modules\Admin_Ad_Blocker::class,
 		Modules\Block_Editor::class,
 		Modules\Cleanup::class,
 		Modules\Comments::class,


### PR DESCRIPTION
The WordPress dashboard is sometimes overcrowded with ads from freemium plugins. We don't deny them the space to do so generally, but we don't need our clients to see this constantly. We've made this call as an agency and clients should be safe from this.

This PR adds simple CSS rules that block various IDs around the admin interface that can be seen as ads. We use this liberally.

It also removes a series of menu pages that are strictly about premium features (unless we have the premium plugin) or just ads.