### PR TITLE
Matomo Tracking Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ configuration.
 `bm_wpexp_matomo_enable_user_id` - Return true to track the user ID. This is not compatible with cookie-less.
 `bm_wpexp_matomo_enable_subdomains` - Return true to enable subdomain tracking.
 `bm_wpexp_matomo_subdomains_domain` - Return the domain name for subdomain tracking (for example: example.com). Requires for subdomain tracking.
+`bm_wpexp_matomo_load_outside_production` - Return true to load the tracking code outside of a defined production environment.
 
 `bm_wpexp_matomo_configuration_before_pageview` - This action lets you further customize and configure the tracking code.
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,13 @@ For almost every feature there is a filter, constant or action allowing you to c
 - Show staging environment notice publically for administrators.
 - Disable indexing for non-production environments.
 
+### Matomo
+
+- Integrates with BM Analytics for easy configuration.
+- Configure the tracking code with common settings through filters.
+- Ability to configure another Matomo instance for the tracking code.
+- Automatically tracks site search.
+
 ### Mail
 
 - Allows easy configuration of sending via SMTP instead of PHP Sendmail.
@@ -184,6 +191,18 @@ configuration.
 `BM_WP_SMTP_PASSWORD` - Define the SMTP e-mail account password to send through.
 `BM_WP_SMTP_PORT` - Set which port the connection should be made through. Should be set as an integer. Defaults to `587`.
 `BM_WP_SMTP_SECURITY` - Set the sending security for the SMTP server. Defaults to `tls`.
+
+### Matomo
+
+`BM_WP_MATOMO_SITE_ID` - Set the site id from Matomo.
+`bm_wpexp_matomo_enabled` - Return this filter false to disable the Matomo module completely (by default it is enabled if the site ID is set).
+`bm_wpexp_matomo_url` - Return a string URL with the Matomo instance base URL.
+`bm_wpexp_matomo_require_cookie_consent` - Return false to disable the automatic cookie consent requirement (integrates with Ilmenite Cookie Consent)
+`bm_wpexp_matomo_enable_user_id` - Return true to track the user ID. This is not compatible with cookie-less.
+`bm_wpexp_matomo_enable_subdomains` - Return true to enable subdomain tracking.
+`bm_wpexp_matomo_subdomains_domain` - Return the domain name for subdomain tracking (for example: example.com). Requires for subdomain tracking.
+
+`bm_wpexp_matomo_configuration_before_pageview` - This action lets you further customize and configure the tracking code.
 
 ### REST API
 

--- a/src/Modules/Matomo.php
+++ b/src/Modules/Matomo.php
@@ -11,6 +11,10 @@ class Matomo extends Module {
 			return;
 		}
 
+		if ( wp_get_environment_type() !== 'production' && false === apply_filters( 'bm_wpexp_matomo_load_outside_production', false ) ) {
+			return;
+		}
+
 		// Don't enable if no site ID is set.
 		if ( empty( self::get_site_id() ) ) {
 			return;

--- a/src/Modules/Matomo.php
+++ b/src/Modules/Matomo.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace BernskioldMedia\WP\Experience\Modules;
+
+class Matomo extends Module {
+
+	public static function hooks(): void {
+
+		// Allow disabling of module.
+		if ( true !== apply_filters( 'bm_wpexp_matomo_enabled', true ) ) {
+			return;
+		}
+
+		// Don't enable if no site ID is set.
+		if ( empty( self::get_site_id() ) ) {
+			return;
+		}
+
+		add_action( 'wp_head', [ self::class, 'analytics_code' ], 9999 ); // Hook far down.
+
+	}
+
+	protected static function get_site_id(): string {
+		return defined( 'BM_WP_MATOMO_SITE_ID' ) ? BM_WP_MATOMO_SITE_ID : '';
+	}
+
+	protected static function get_instance_url(): string {
+		return apply_filters( 'bm_wpexp_matomo_url', 'https://analytics.bmedia.io/' );
+	}
+
+	public static function analytics_code(): void {
+		global $wp_query;
+
+		$site_id               = self::get_site_id();
+		$enable_cookie_consent = apply_filters( 'bm_wpexp_matomo_require_cookie_consent', true );
+		$enable_user_id        = apply_filters( 'bm_wpexp_matomo_enable_user_id', false );
+		$enable_subdomains     = apply_filters( 'bm_wpexp_matomo_enable_subdomains', false );
+		$domain                = apply_filters( 'bm_wpexp_matomo_subdomains_domain', '' );
+		$matomo_url            = self::get_instance_url();
+
+		?>
+		<script>
+			var _paq = window._paq = window._paq || [];
+			<?php if($enable_cookie_consent) : ?>
+			_paq.push( [ "requireCookieConsent" ] );
+			<?php endif; ?>
+			<?php do_action( 'bm_wpexp_matomo_configuration_before_pageview' ); ?>
+			<?php if($enable_user_id && is_user_logged_in()) : ?>
+			_paq.push( [ "setUserId", '<?php echo esc_js( get_current_user_id() ); ?>' ] );
+			<?php endif; ?>
+			<?php if(is_search()) : ?>
+			_paq.push( [
+				"trackSiteSearch",
+				"<?php echo esc_js( get_search_query() ); ?>",
+				false,
+				<?php echo esc_js( $wp_query->found_posts ); ?>
+			] );
+			<?php else : ?>
+			_paq.push( [ "trackPageView" ] );
+			<?php endif; ?>
+			_paq.push( [ "enableLinkTracking" ] );
+			( function() {
+				var u = "<?php echo esc_js( $matomo_url ); ?>";
+				_paq.push( [ "setTrackerUrl", u + "matomo.php" ] );
+				_paq.push( [ "setSiteId", "<?php echo esc_js( $site_id ); ?>" ] );
+				<?php if($enable_subdomains && ! empty( $domain )) : ?>
+				_paq.push( [ "setCookieDomain", "*.<?php echo esc_js( $domain ); ?>" ] );
+				_paq.push( [ "setDomains", "*.<?php echo esc_js( $domain ); ?>" ] );
+				<?php endif; ?>
+				var d   = document, g = d.createElement( "script" ), s = d.getElementsByTagName( "script" )[ 0 ];
+				g.async = true;
+				g.src   = u + "matomo.js";
+				s.parentNode.insertBefore( g, s );
+			} )();
+		</script>
+		<?php
+	}
+
+	public static function analytics_noscript(): void {
+		?>
+		<noscript>
+			<p>
+				<img src="<?php echo esc_attr( self::get_instance_url() ); ?>/matomo.php?idsite=<?php echo esc_attr( self::get_site_id() ); ?>&rec=1" style="border:0;" alt="" />
+			</p>
+		</noscript>
+		<?php
+	}
+
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,6 +2,7 @@
 
 namespace BernskioldMedia\WP\Experience;
 
+use BernskioldMedia\WP\Experience\Modules\Module;
 use BernskioldMedia\WP\Experience\Modules\Security\TwoFactorAuthentication;
 use BernskioldMedia\WP\Experience\Rest\OhDear_Application_Health;
 use BMWPEXP_Vendor\BernskioldMedia\WP\PluginBase\BasePlugin;
@@ -34,6 +35,7 @@ class Plugin extends BasePlugin {
 		Modules\Dashboard::class,
 		Modules\Environments::class,
 		Modules\Mail::class,
+		Modules\Matomo::class,
 		Modules\Media::class,
 		Modules\Multisite::class,
 		Modules\Plugins::class,


### PR DESCRIPTION
This PR adds a Matomo tracking module with the defaults as we like them. Simply define the site ID in the application config to enable.