### PR TITLE
User access to admin pages

### DIFF
--- a/src/Admin/Admin_Pages.php
+++ b/src/Admin/Admin_Pages.php
@@ -6,6 +6,7 @@
 
 namespace BernskioldMedia\WP\Experience\Admin;
 
+use BernskioldMedia\WP\Experience\Modules\Users;
 use BernskioldMedia\WP\Experience\Plugin;
 use BMWPEXP_Vendor\BernskioldMedia\WP\PluginBase\Interfaces\Hookable;
 
@@ -98,6 +99,10 @@ class Admin_Pages implements Hookable {
 		if ( defined( 'BM_WP_ENABLE_IMPORT_EXPORT' ) && BM_WP_ENABLE_IMPORT_EXPORT ) {
 			return;
 		}
+
+        if( Users::is_agency(wp_get_current_user()) ) {
+            return;
+        }
 
 		remove_submenu_page( 'tools.php', 'export.php' );
 		remove_submenu_page( 'tools.php', 'import.php' );

--- a/src/Modules/Users.php
+++ b/src/Modules/Users.php
@@ -85,4 +85,21 @@ class Users extends Module {
     public static function get_email_domains(): array {
         return apply_filters( 'bm_wpexp_authors_email_domains', self::EMAIL_DOMAINS );
     }
+
+    public static function is_agency( $user ){
+
+        $is_agency = false;
+        foreach ( self::get_email_domains() as $domain ) {
+            if ( $is_agency !== true && false !== stripos( $user->user_email, $domain ) ) {
+                $is_agency = true;
+            }
+        }
+
+        if( $is_agency ){
+            return true;
+        }
+        else{
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
- Make sure agency/allowed email addresses has access to ACF-pages in production
- Make sure agency/allowed email addresses has access to import & export pages
- Make sure non superadmin user has no access to Litespeed. Not via admin menu or direct URL